### PR TITLE
Drop lintian override that is now redundant

### DIFF
--- a/debian/percona-server-server-5.6.lintian-overrides
+++ b/debian/percona-server-server-5.6.lintian-overrides
@@ -2,6 +2,3 @@
 percona-server-server-5.6: embedded-library usr/bin/mysqlbinlog: libmysqlclient
 percona-server-server-5.6: embedded-library usr/bin/mysqltest: libmysqlclient
 percona-server-server-5.6: embedded-library usr/sbin/mysqld: libmysqlclient
-
-# to supress false positive
-percona-server-server-5.6: duplicate-updaterc.d-calls-in-postrm mysql


### PR DESCRIPTION
The postrm no longer calls update-rc.d, so this override is no longer
required.
